### PR TITLE
Update job script for decombinator v5

### DIFF
--- a/jobs/cshpc/dcr_job.qsub.sh
+++ b/jobs/cshpc/dcr_job.qsub.sh
@@ -21,15 +21,15 @@ hostname
 date
 echo $PWD
 
-# Specify locations of pipeline script and tags
+# Specify location of tags
 PROJECTDIR=/SAN/colcc/tcr_decombinator
-PIPELINE=$PROJECTDIR/Decombinator/dcr_pipeline.py
 TAGS=$PROJECTDIR/Decombinator-Tags-FASTAs/
 
 # Setup python enviroment
-source /share/apps/source_files/python/python-3.10.0.source
-source $PROJECTDIR/decombinator_venv/bin/activate
+source /share/apps/source_files/python/python-3.11.9.source
+source $PROJECTDIR/decombinator5_venv/bin/activate
 python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'
+echo "Decombinator version $(decombinator --version)"
 
 # Get file name from directory and strip any directory information
 FILENAME=$(find . -type f -name *_1.fq.gz -exec basename {} \;)
@@ -37,8 +37,8 @@ echo $FILENAME
 
 echo "Species assumed to be Homo sapiens, please specify if not"
 echo "=== Alpha Chain Pipeline ==="
-python $PIPELINE -fq $FILENAME -br R2 -bl 42 -c a -ol M13 -tfdir $TAGS
+decombinator -fq $FILENAME -br R2 -bl 42 -c a -ol M13 -tfdir $TAGS
 echo "=== Beta Chain Pipeline ==="
-python $PIPELINE -fq $FILENAME -br R2 -bl 42 -c b -ol M13 -tfdir $TAGS
+decombinator -fq $FILENAME -br R2 -bl 42 -c b -ol M13 -tfdir $TAGS
 
 echo "Job complete."

--- a/jobs/cshpc/dcr_job.qsub.sh
+++ b/jobs/cshpc/dcr_job.qsub.sh
@@ -2,8 +2,8 @@
 # Runtime is either seconds or hours:min:sec
 # 12hr selected to allow for instances of extended collapsing and server delay
 
-#$ -l tmem=15G
-#$ -l h_vmem=15G
+#$ -l tmem=32G
+#$ -l h_vmem=32G
 #$ -l h_rt=24:00:00
 
 # These are optional flags but you probably want them in all jobs
@@ -12,6 +12,7 @@
 #$ -j y
 #$ -N tcr_pipeline
 #$ -cwd
+#$ -l h=!arbuckle
 
 # Most recent sequencing protocols return raw data that is already demultiplexed.
 # Therefore, for most cases nowadays, running Demultiplexor is no longer required.
@@ -37,8 +38,8 @@ echo $FILENAME
 
 echo "Species assumed to be Homo sapiens, please specify if not"
 echo "=== Alpha Chain Pipeline ==="
-decombinator -fq $FILENAME -br R2 -bl 42 -c a -ol M13 -tfdir $TAGS
+decombinator pipeline -in $FILENAME -br R2 -bl 42 -c a -ol M13 -tfdir $TAGS
 echo "=== Beta Chain Pipeline ==="
-decombinator -fq $FILENAME -br R2 -bl 42 -c b -ol M13 -tfdir $TAGS
+decombinator pipeline -in $FILENAME -br R2 -bl 42 -c b -ol M13 -tfdir $TAGS
 
 echo "Job complete."

--- a/jobs/cshpc/repack.sh
+++ b/jobs/cshpc/repack.sh
@@ -9,7 +9,7 @@ TOOLS=$PROJECTDIR/Decombinator-Tools
 
 (return 0 2>/dev/null) && sourced=1 || sourced=0
 
-read -p "How many .tsv files are you expecting?: " EXPECTED
+read -p "How many .tsv files in total are you expecting?: " EXPECTED
 ACTUAL=$(find temp/ -type f -name "*tsv*" | wc -l)
 
 if [ $ACTUAL -eq $EXPECTED ]; then

--- a/jobs/cshpc/summarise.sh
+++ b/jobs/cshpc/summarise.sh
@@ -3,6 +3,7 @@
 
 PROJECTDIR=/SAN/colcc/tcr_decombinator
 TOOLS=$PROJECTDIR/Decombinator-Tools
+TARGET_DIR=temp/
 
 (return 0 2>/dev/null) && sourced=1 || sourced=0
 
@@ -23,18 +24,30 @@ fi
 # Create temp directory for logs
 echo "Creating temporary directory..."
 mkdir temp_logs
+DEST_DIR=temp_logs/
 
-echo "Copying logs..."
-find temp/ -type f -name "*.csv*" -exec cp {} temp_logs/ \;
+find $TARGET_DIR -type f -name "*.csv" | awk -v dest_dir="$DEST_DIR" -F'[_.]' '{
+    date = $1 "_" $2 "_" $3;
+    raw_id = substr($0, index($0, $4))
+    if (!seen[raw_id] || date > seen[raw_id]) {
+        seen[raw_id] = date;
+        files[raw_id] = $0;
+    }
+} END {
+    for (id in files) {
+        print "Copying " files[id] " to " dest_dir;
+        system("cp \"" files[id] "\" \"" dest_dir "\"");
+    }
+}'
 
 # Generate summary sheet
 echo "Creating temporary summary sheet..."
-source /share/apps/source_files/python/python-3.10.0.source
+source /share/apps/source_files/python/python-3.11.9.source
 current_time=$(date +"%Y-%m-%d_%H-%M-%S")
 python3 $TOOLS/analysis/LogSummary.py -l temp_logs/ -o Summary_${POOLID}_${current_time}.csv -s $POOLID.csv
 
 # Remove temp logs
 echo "Removing temporary directory..."
-rm -r temp_logs
+rm -r temp_logs/
 
 echo "Summary sheet generated."


### PR DESCRIPTION
**Issue:** The impending update of Decombinator to version 5 will introduce a breaking change to the existing `cshpc` pipeline due to Decombinator now being a CLI app.

**Solution**: This PR updates the job script used in `cshpc` to handle the new syntax used to call Decombinator. This will result in there being no usage change for pipeline users.